### PR TITLE
Update guac-install.sh

### DIFF
--- a/guac-install.sh
+++ b/guac-install.sh
@@ -103,7 +103,7 @@ if [ $MACHINE_ARCH="x86_64" ]; then ARCH="64"; elif [ $MACHINE_ARCH="i686" ]; th
 NGINX_URL=https://nginx.org/packages/$OS_NAME_L/$MAJOR_VER/$MACHINE_ARCH/ # Set nginx url for RHEL or CentOS
 
 # Server LAN IP
-GUAC_SERVER_IP=$(hostname -I | tr -d " ")
+GUAC_SERVER_IP=$(hostname -I | sed 's/ .*//')
 }
 
 #####      SOURCE VARIABLES       ###################################


### PR DESCRIPTION
using sed instead of tr to handle pulling a single IP from a multi-NIC system. hostname man page states the IP's provided by -I are essentially not in any given order.

I will look into providing a prompt to allow automatically using the IP pulled or manually entering the desired IP.