### PR TITLE
Update guac-install.sh

### DIFF
--- a/guac-install.sh
+++ b/guac-install.sh
@@ -1139,10 +1139,10 @@ finishguac () {
 # Generate Guacamole Configuration File
 sleep 1 | echo -e "\n${Bold}Generating Guacamole configuration file..." | pv -qL 25; echo -e "\nGenerating Guacamole configuration file..." >> $logfile  2>&1
 echo "# Hostname and port of guacamole proxy
-guacd-hostname: ${GUACSERVER_HOSTNAME}
+guacd-hostname: localhost
 guacd-port:     ${GUAC_PORT}
 # MySQL properties
-mysql-hostname: ${GUACSERVER_HOSTNAME}
+mysql-hostname: localhost
 mysql-port: ${MYSQL_PORT}
 mysql-database: ${DB_NAME}
 mysql-username: ${DB_USER}


### PR DESCRIPTION
Removed deprecated variable for the parameters assigned to guacd-hostname and mysql-hostname in the guacamole.properties file. These are statically set to localhost now. As per Guac documentation, when left blank they default to local host and since the variable was never assigned they were blank. As the script configures both guacd and mariadb locally, there is not reason for them not to be localhost.