### PR TITLE
Update guac-install.sh

### DIFF
--- a/guac-install.sh
+++ b/guac-install.sh
@@ -1108,10 +1108,10 @@ if [ $GUAC_SOURCE == "Git" ]; then
 		wget ${MAVEN_URL}${MAVEN_BIN}
 		tar -xvzf ${MAVEN_BIN}
 		ln -s ${MAVEN_FN} maven
-		export PATH=/opt/maven/bin:${PATH}
 		rm -rf /opt/${MAVEN_BIN}
 	} &
 	s_echo "n" "-Installing Apache Maven for git...    "; spinner
+	export PATH=/opt/maven/bin:${PATH}
 	cd ~
 fi
 
@@ -1220,7 +1220,7 @@ s_echo "y" "${Bold}Install Guacamole Client"
 
 if [ $GUAC_SOURCE == "Git" ]; then
 	cd guacamole-client/
-	/opt/maven/bin/mvn package &
+	mvn package &
 	s_echo "n" "${Reset}-Compiling Guacamole Client...    "; spinner
 
 	mv -v guacamole/target/guacamole-${GUAC_VER}.war ${LIB_DIR}guacamole.war &

--- a/guac-install.sh
+++ b/guac-install.sh
@@ -29,7 +29,7 @@ ADM_POC="Local Admin, admin@admin.com"  # Point of contact for the Guac server a
 
 # Versions
 GUAC_STBL_VER="1.0.0" # Latest stable version of Guac from https://guacamole.apache.org/releases/
-MYSQL_CON_VER="5.1.47" # Working stable release of MySQL Connecter J
+MYSQL_CON_VER="8.0.15" # Working stable release of MySQL Connecter J
 LIBJPEG_VER="2.0.2" # Latest stable version of libjpeg-turbo
 MAVEN_VER="3.6.1" # Latest stable version of Apache Maven
 

--- a/guac-install.sh
+++ b/guac-install.sh
@@ -31,7 +31,7 @@ ADM_POC="Local Admin, admin@admin.com"  # Point of contact for the Guac server a
 GUAC_STBL_VER="1.0.0" # Latest stable version of Guac from https://guacamole.apache.org/releases/
 MYSQL_CON_VER="5.1.47" # Working stable release of MySQL Connecter J
 LIBJPEG_VER="2.0.2" # Latest stable version of libjpeg-turbo
-MAVEN_VER="3.6.0" # Latest stable version of Apache Maven
+MAVEN_VER="3.6.1" # Latest stable version of Apache Maven
 
 # Ports
 GUAC_PORT="4822"
@@ -1220,7 +1220,7 @@ s_echo "y" "${Bold}Install Guacamole Client"
 
 if [ $GUAC_SOURCE == "Git" ]; then
 	cd guacamole-client/
-	mvn package &
+	/opt/maven/bin/mvn package &
 	s_echo "n" "${Reset}-Compiling Guacamole Client...    "; spinner
 
 	mv -v guacamole/target/guacamole-${GUAC_VER}.war ${LIB_DIR}guacamole.war &

--- a/guac-install.sh
+++ b/guac-install.sh
@@ -1039,7 +1039,7 @@ else
 fi
 
 # Install RPMFusion Repo
-chk_installed "rpmfusion"
+chk_installed "rpmfusion-free-release"
 
 if [ $RETVAL -eq 0 ]; then
 	s_echo "n" "-RPMFusion is installed."

--- a/guac-install.sh
+++ b/guac-install.sh
@@ -29,7 +29,7 @@ ADM_POC="Local Admin, admin@admin.com"  # Point of contact for the Guac server a
 
 # Versions
 GUAC_STBL_VER="1.0.0" # Latest stable version of Guac from https://guacamole.apache.org/releases/
-MYSQL_CON_VER="8.0.15" # Working stable release of MySQL Connecter J
+MYSQL_CON_VER="5.1.47" # Working stable release of MySQL Connecter J
 LIBJPEG_VER="2.0.2" # Latest stable version of libjpeg-turbo
 MAVEN_VER="3.6.1" # Latest stable version of Apache Maven
 


### PR DESCRIPTION
Latest stable version of maven changed to 3.6.1
Full path for maven added to compile guac-client