### PR TITLE
Testing freerdp fix

### DIFF
--- a/guac-install.sh
+++ b/guac-install.sh
@@ -101,8 +101,8 @@ OS_NAME_L="$(echo $OS_NAME | tr '[:upper:]' '[:lower:]')" # Set lower case rhel 
 # Outputs the major.minor.release number of the OS, Ex: 7.6.1810 and splits the 3 parts.
 MAJOR_VER=`cat /etc/redhat-release | grep -oP "[0-9]+" | sed -n 1p` # Return the leftmost digit representing major version
 MINOR_VER=`cat /etc/redhat-release | grep -oP "[0-9]+" | sed -n 2p` # Returns the middle digit representing minor version
-# Will need to check that RHEL returns the same results. Need to test on RHEL.
-RELEASE_VER=`cat /etc/redhat-release | grep -oP "[0-9]+" | sed -n 3p` # Returns the rightmost digits representing release number
+# Placeholder in case this info is ever needed. RHEL does not have release number, only major.minor
+# RELEASE_VER=`cat /etc/redhat-release | grep -oP "[0-9]+" | sed -n 3p` # Returns the rightmost digits representing release number
 
 #Set arch used in some paths
 MACHINE_ARCH=`uname -m`
@@ -156,7 +156,7 @@ clear
 
 echo -e "   ${Reset}${Bold}----====Gucamole Installation Script====----\n       ${Reset}Guacamole Remote Desktop Gateway\n"
 echo -e "   ${Bold}***        Source Menu     ***\n"
-echo "   OS: ${Yellow}${OS_NAME} ${MAJOR_VER} ${MACHINE_ARCH}${Reset}"
+echo "   OS: ${Yellow}${OS_NAME} ${MAJOR_VER}.${MINOR_VER} ${MACHINE_ARCH}${Reset}"
 echo -e "   ${Bold}Stable Version: ${Yellow}${GUAC_STBL_VER}${Reset} || ${Bold}Git Version: ${Yellow}${GUAC_GIT_VER}${Reset}\n"
 
 while true; do
@@ -1039,11 +1039,11 @@ s_echo "y" "${Bold}Installing Required Dependencies"
 		if [ $OS_NAME == "RHEL" ]; then
 			# Create repo to CentOS-Vault 7.6 for freerdp-devel 1.0.2
 			echo "[C7.6.1810-base]
-			name=CentOS-7.6.1810 - Base
-			baseurl=http://vault.centos.org/7.6.1810/os/$basearch/
-			gpgcheck=1
-			gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
-			enabled=0" > /etc/yum.repos.d/CentOS-Vault.repo
+name=CentOS-7.6.1810 - Base
+baseurl=http://vault.centos.org/7.6.1810/os/\$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+enabled=0" > /etc/yum.repos.d/CentOS-Vault.repo
 		fi	
 				
 		# Install freerdp 1.x from CentOS-Vault repo

--- a/guac-install.sh
+++ b/guac-install.sh
@@ -1042,7 +1042,7 @@ s_echo "y" "${Bold}Installing Required Dependencies"
 name=CentOS-7.6.1810 - Base
 baseurl=http://vault.centos.org/7.6.1810/os/\$basearch/
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+gpgkey=http://vault.centos.org/RPM-GPG-KEY-CentOS-7
 enabled=0" > /etc/yum.repos.d/CentOS-Vault.repo
 		fi	
 				

--- a/guac-install.sh
+++ b/guac-install.sh
@@ -25,7 +25,7 @@ set -E
 ######  UNIVERSAL VARIABLES  #########################################
 # USER CONFIGURABLE #
 # Generic
-SCRIPT_BUILD="2019_9_23" # Scripts Date for last modified as "yyyy_mm_dd"
+SCRIPT_BUILD="2019_10_17" # Scripts Date for last modified as "yyyy_mm_dd"
 ADM_POC="Local Admin, admin@admin.com"  # Point of contact for the Guac server admin
 
 # Versions
@@ -1035,8 +1035,19 @@ s_echo "y" "${Bold}Installing Required Dependencies"
 	if [[ $MAJOR_VER == "7" && $MINOR_VER -lt "7" ]]; then
 		yum install -y cairo-devel dialog ffmpeg-devel freerdp-devel freerdp-plugins gcc gnu-free-mono-fonts libjpeg-turbo-devel libjpeg-turbo-official libpng-devel libssh2-devel libtelnet-devel libvncserver-devel libvorbis-devel libwebp-devel mariadb mariadb-server nginx openssl-devel pango-devel policycoreutils-python pulseaudio-libs-devel setroubleshoot tomcat uuid-devel
 	else # assume 7.7 or a higher 7.x, is not a solution for 8.x
+		# If OS is RHEL, create required repo file
+		if [ $OS_NAME == "RHEL" ]; then
+			# Create repo to CentOS-Vault 7.6 for freerdp-devel 1.0.2
+			echo "[C7.6.1810-base]
+			name=CentOS-7.6.1810 - Base
+			baseurl=http://vault.centos.org/7.6.1810/os/$basearch/
+			gpgcheck=1
+			gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+			enabled=0" > /etc/yum.repos.d/CentOS-Vault.repo
+		fi	
+				
 		# Install freerdp 1.x from CentOS-Vault repo
-		yum install -y freerdp-devel freerdp-plugins --enablerepo=C7.6.1810-base --disablerepo=base --disablerepo=updates
+		yum install -y freerdp-devel freerdp-plugins --disablerepo="*" --enablerepo=C7.6.1810-base
 		# Prevent updating freerdp in the future
 		sed -i "\$aexclude=freerdp*" /etc/yum.conf
 		# Install other packages as required
@@ -1354,7 +1365,8 @@ s_echo "n" "${Reset}-Making Nginx config backup...    "; spinner
 	proxy_cookie_path /guacamole/ ${GUAC_URIPATH};
 	access_log off;
 	}
-}" > /etc/nginx/conf.d/guacamole.conf; } &
+}" > /etc/nginx/conf.d/guacamole.conf 
+} &
 s_echo "n" "${Reset}-Generate Nginx guacamole.config...    "; spinner
 
 # HTTPS/SSL Nginx Conf

--- a/guac-install.sh
+++ b/guac-install.sh
@@ -185,7 +185,7 @@ clear
 
 echo -e "   ${Reset}${Bold}----====Gucamole Installation Script====----\n       ${Reset}Guacamole Remote Desktop Gateway\n"
 echo -e "   ${Bold}***     ${SUB_MENU_TITLE}     ***\n"
-echo "   OS: ${Yellow}${OS_NAME} ${MAJOR_VER} ${MACHINE_ARCH}${Reset}"
+echo "   OS: ${Yellow}${OS_NAME} ${MAJOR_VER}.${MINOR_VER} ${MACHINE_ARCH}${Reset}"
 echo -e "   ${Bold}Source/Version: ${Yellow}${GUAC_SOURCE} ${GUAC_VER}${Reset}\n"
 }
 


### PR DESCRIPTION
Updates to allow the script to handle an issue related to RHEL/CentOS 7.7 and Guacamole 1.0.0, regarding freerdp. In 7.7, freerdp was updated to 2.x from 1.0.2. Guacamole 1.0.0 requires freerdp 1.x to work properly.

These updates evaluate the major and minor versions of the OS, install as per "normal" if its 7.6 or lower and using the CentOS-Vault.repo if its 7.7 or a greater minor version. These changes do not account for RHEL/CentOS 8.x. An additional check is on if the OS is RHEL and if so the CentOS-Vault.repo is created specifically with whats needed to install freerdp 1.x (if someone knows of a more direct or better method for installing freerdp 1.x from a 1st party RHEL repo, please let me know).

It should be noted that the CentOS-Vault repo, just as it is on CentOS itself, uses an HTTP baseurl, not HTTPS. To get the repo to work with RHEL, I also changed the line for gpg key to pull it from the gpg key from the site, again over HTTP. When I tried HTTPS, the site worked in a browser but the repo would fail. Please asses the risk for yourself.

RHEL/CentOS 7.7 appear to work as expected after the updates made to the script in testing. Still, follow the same level of caution advised for this script, test it and be sure before trying in production.