### PR TITLE
Testing freerdp revise

### DIFF
--- a/guac-install.sh
+++ b/guac-install.sh
@@ -25,12 +25,12 @@ set -E
 ######  UNIVERSAL VARIABLES  #########################################
 # USER CONFIGURABLE #
 # Generic
-SCRIPT_BUILD="2019_10_17" # Scripts Date for last modified as "yyyy_mm_dd"
+SCRIPT_BUILD="2019_10_18" # Scripts Date for last modified as "yyyy_mm_dd"
 ADM_POC="Local Admin, admin@admin.com"  # Point of contact for the Guac server admin
 
 # Versions
 GUAC_STBL_VER="1.0.0" # Latest stable version of Guac from https://guacamole.apache.org/releases/
-MYSQL_CON_VER="8.0.17" # Working stable release of MySQL Connecter J
+MYSQL_CON_VER="8.0.18" # Working stable release of MySQL Connecter J
 MAVEN_VER="3.6.2" # Latest stable version of Apache Maven
 
 # Ports
@@ -1037,19 +1037,19 @@ s_echo "y" "${Bold}Installing Required Dependencies"
 	else # assume 7.7 or a higher 7.x, is not a solution for 8.x
 		# If OS is RHEL, create required repo file
 		if [ $OS_NAME == "RHEL" ]; then
-			# Create repo to CentOS-Vault 7.6 for freerdp-devel 1.0.2
-			echo "[C7.6.1810-base]
-name=CentOS-7.6.1810 - Base
-baseurl=http://vault.centos.org/7.6.1810/os/\$basearch/
-gpgcheck=1
-gpgkey=http://vault.centos.org/RPM-GPG-KEY-CentOS-7
-enabled=0" > /etc/yum.repos.d/CentOS-Vault.repo
-		fi	
-				
-		# Install freerdp 1.x from CentOS-Vault repo
-		yum install -y freerdp-devel freerdp-plugins --disablerepo="*" --enablerepo=C7.6.1810-base
-		# Prevent updating freerdp in the future
-		sed -i "\$aexclude=freerdp*" /etc/yum.conf
+			yum install -y yum-versionlock
+
+			yum versionlock add freerdp-*-1.0.2-15* freerdp-1.0.2-15*
+
+			yum install -y freerdp-devel-1.0.2-15.el7 freerdp-plugins-1.0.2-15.el7
+
+		else
+			# Install freerdp 1.x from CentOS-Vault repo
+			yum install -y freerdp-devel freerdp-plugins --disablerepo="*" --enablerepo=C7.6.1810-base
+			# Prevent updating freerdp in the future
+			sed -i "\$aexclude=freerdp*" /etc/yum.conf
+		fi
+
 		# Install other packages as required
 		yum install -y cairo-devel dialog ffmpeg-devel gcc gnu-free-mono-fonts libjpeg-turbo-devel libjpeg-turbo-official libpng-devel libssh2-devel libtelnet-devel libvncserver-devel libvorbis-devel libwebp-devel mariadb mariadb-server nginx openssl-devel pango-devel policycoreutils-python pulseaudio-libs-devel setroubleshoot tomcat uuid-devel
 	fi

--- a/guac-install.sh
+++ b/guac-install.sh
@@ -1035,19 +1035,16 @@ s_echo "y" "${Bold}Installing Required Dependencies"
 	if [[ $MAJOR_VER == "7" && $MINOR_VER -lt "7" ]]; then
 		yum install -y cairo-devel dialog ffmpeg-devel freerdp-devel freerdp-plugins gcc gnu-free-mono-fonts libjpeg-turbo-devel libjpeg-turbo-official libpng-devel libssh2-devel libtelnet-devel libvncserver-devel libvorbis-devel libwebp-devel mariadb mariadb-server nginx openssl-devel pango-devel policycoreutils-python pulseaudio-libs-devel setroubleshoot tomcat uuid-devel
 	else # assume 7.7 or a higher 7.x, is not a solution for 8.x
+		# Prevent updating freerdp in the future
+		yum install -y yum-versionlock
+		yum versionlock add freerdp-*-1.0.2-15* freerdp-1.0.2-15*
+		
 		# If OS is RHEL, create required repo file
 		if [ $OS_NAME == "RHEL" ]; then
-			yum install -y yum-versionlock
-
-			yum versionlock add freerdp-*-1.0.2-15* freerdp-1.0.2-15*
-
 			yum install -y freerdp-devel-1.0.2-15.el7 freerdp-plugins-1.0.2-15.el7
-
 		else
 			# Install freerdp 1.x from CentOS-Vault repo
 			yum install -y freerdp-devel freerdp-plugins --disablerepo="*" --enablerepo=C7.6.1810-base
-			# Prevent updating freerdp in the future
-			sed -i "\$aexclude=freerdp*" /etc/yum.conf
 		fi
 
 		# Install other packages as required


### PR DESCRIPTION
Cleaned up the code related to freerdp for both RHEL and CentOS. It appears the freerdp 1.0.2 packages are available from the 1st party RHEL repos as well. Added the package yum-versionlock which is a yum plugin to essentially exclude packages from updates. In this case by adding all non-version 1.0.2 freerdp to the list of packages to exclude.

Updated MySQL Connector J version to 8.0.18 from 8.0.17.