### PR TITLE
Testing guac 1.1.0

### DIFF
--- a/guac-install.sh
+++ b/guac-install.sh
@@ -25,11 +25,11 @@ set -E
 ######  UNIVERSAL VARIABLES  #########################################
 # USER CONFIGURABLE #
 # Generic
-SCRIPT_BUILD="2020_1_21" # Scripts Date for last modified as "yyyy_mm_dd"
+SCRIPT_BUILD="2020_02_04" # Scripts Date for last modified as "yyyy_mm_dd"
 ADM_POC="Local Admin, admin@admin.com"  # Point of contact for the Guac server admin
 
 # Versions
-GUAC_STBL_VER="1.0.0" # Latest stable version of Guac from https://guacamole.apache.org/releases/
+GUAC_STBL_VER="1.1.0" # Latest stable version of Guac from https://guacamole.apache.org/releases/
 MYSQL_CON_VER="8.0.19" # Working stable release of MySQL Connecter J
 MAVEN_VER="3.6.3" # Latest stable version of Apache Maven
 
@@ -1032,38 +1032,38 @@ s_echo "y" "${Bold}Installing Required Dependencies"
 # Install Required Packages
 {
 	# check if OS is major version 7 AND minor version is less than 7, IE: 7.6 or lower.
-	if [[ $MAJOR_VER == "7" && $MINOR_VER -lt "7" ]]; then
-		yum install -y cairo-devel dialog ffmpeg-devel freerdp-devel freerdp-plugins gcc gnu-free-mono-fonts libjpeg-turbo-devel libjpeg-turbo-official libpng-devel libssh2-devel libtelnet-devel libvncserver-devel libvorbis-devel libwebp-devel mariadb mariadb-server nginx openssl-devel pango-devel policycoreutils-python pulseaudio-libs-devel setroubleshoot tomcat uuid-devel
-	else # assume 7.7 or a higher 7.x, is not a solution for 8.x
+	#if [[ $MAJOR_VER == "7" && $MINOR_VER -lt "7" ]]; then
+		yum install -y cairo-devel dialog ffmpeg-devel freerdp-devel freerdp-plugins gcc gnu-free-mono-fonts libjpeg-turbo-devel libjpeg-turbo-official libpng-devel libssh2-devel libtelnet-devel libvncserver-devel libvorbis-devel libwebp-devel libwebsockets-devel mariadb mariadb-server nginx openssl-devel pango-devel policycoreutils-python pulseaudio-libs-devel setroubleshoot tomcat uuid-devel
+	#else # assume 7.7 or a higher 7.x, is not a solution for 8.x
 		# Install yum-versionlock
-		yum install -y yum-versionlock
+		#yum install -y yum-versionlock
 
 		# If OS is RHEL, create required repo file
-		if [ $OS_NAME == "RHEL" ]; then
+		#if [ $OS_NAME == "RHEL" ]; then
 			# Prevent updating freerdp in the future
-			yum versionlock add freerdp-*-1.0.2-15* freerdp-1.0.2-15*
+			#yum versionlock add freerdp-*-1.0.2-15* freerdp-1.0.2-15*
 
-			yum install -y freerdp-devel-1.0.2-15.el7_6.1 freerdp-plugins-1.0.2-15.el7_6.1
-		else
-			yum install -y yum-utils
-			yum-config-manager --enable C7.6.1810-base
+			#yum install -y freerdp-devel-1.0.2-15.el7_6.1 freerdp-plugins-1.0.2-15.el7_6.1
+		#else
+			#yum install -y yum-utils
+			#yum-config-manager --enable C7.6.1810-base
 
 			# Prevent updating freerdp in the future
-			yum versionlock add freerdp-*-1.0.2-15* freerdp-1.0.2-15*
+			#yum versionlock add freerdp-*-1.0.2-15* freerdp-1.0.2-15*
 
 			# Install freerdp 1.x from CentOS-Vault repo
-			yum install -y freerdp-devel freerdp-plugins --disablerepo="*" --enablerepo=C7.6.1810-base
-		fi
+			#yum install -y freerdp-devel freerdp-plugins --disablerepo="*" --enablerepo=C7.6.1810-base
+		#fi
 		# Install other packages as required
-		yum install -y cairo-devel dialog ffmpeg-devel gcc gnu-free-mono-fonts libjpeg-turbo-devel libjpeg-turbo-official libpng-devel libssh2-devel libtelnet-devel libvncserver-devel libvorbis-devel libwebp-devel mariadb mariadb-server nginx openssl-devel pango-devel policycoreutils-python pulseaudio-libs-devel setroubleshoot tomcat uuid-devel
-	fi
+		#yum install -y cairo-devel dialog ffmpeg-devel gcc gnu-free-mono-fonts libjpeg-turbo-devel libjpeg-turbo-official libpng-devel libssh2-devel libtelnet-devel libvncserver-devel libvorbis-devel libwebp-devel mariadb mariadb-server nginx openssl-devel pango-devel policycoreutils-python pulseaudio-libs-devel setroubleshoot tomcat uuid-devel
+	#fi
 } &
 
 s_echo "n" "${Reset}-Installing required packages...    "; spinner
 
 # Additional packages required by git
 if [ $GUAC_SOURCE == "Git" ]; then
-	{ yum install -y git libtool libwebsockets java-1.8.0-openjdk-devel; } &
+	{ yum install -y git libtool java-1.8.0-openjdk-devel; } &
 	s_echo "n" "-Installing packages required for git...    "; spinner
 
 	#Install Maven

--- a/guac-install.sh
+++ b/guac-install.sh
@@ -51,6 +51,7 @@ JKS_GUAC_PASSWD_DEF="guacamole" # Default Java Keystore password
 JKS_CACERT_PASSWD_DEF="guacamole" # Default CACert Java Keystore password, used with LDAPS
 
 # Misc
+GUACD_USER="guacd"
 GUAC_URIPATH_DEF="/" # Default URI for Guacamole
 DOMAIN_NAME_DEF="localhost" # Default domain name of server
 H_ERR=false # Defualt value of if an error has been triggered, should be false
@@ -1232,6 +1233,18 @@ if [ $GUAC_SOURCE == "Git" ]; then
 	{ find ./guacamole-client/extensions -name "guacamole-auth-jdbc-mysql-${GUAC_VER}.jar" -exec mv -v {} ${LIB_DIR}extensions/ \;; } &
 	s_echo "n" "-Moving Guacamole JDBC extension to extensions dir...    "; spinner
 fi
+
+# Setup guacd user, group and permissions
+{
+	# Create a user and group for guacd with a home folder but no login
+	groupadd ${GUACD_USER}
+	useradd -r ${GUACD_USER} -m -s "/bin/nologin" -g ${GUACD_USER} -c ${GUACD_USER}
+
+	# Set the user that runs guacd
+	sed -i "s/User=daemon/User=${GUACD_USER}/g" /etc/systemd/system/guacd.service
+} &
+s_echo "n" "-Setup guacd user...    "; spinner
+
 appconfigs
 }
 


### PR DESCRIPTION
Updated the scrip to work with Guac 1.1.0 and freerdp 2.x. The script will no longer work with Guac 1.0.0 or freerdp 1.x.

A user is now created to run the guacd service for freerdp to work. This users name and group are defined by the variable GUACD_USER. This user is created as a service account with no login but with a home directory as required by freerdp 2.x. RDP connections should work now, depending on client the connection may need certain options selected to work even if it did not in a prior version of Guac.

I have removed the checks for CentOS/RHEL 7.6 and lower or 7.7 and higher to deal with freerdp 1.x. The script will now only work in CenTOS/RHEL 7.x versions which have freerdp 2.x.

I have added libwebsockets-devel to the list of packages installed to support Kubernetes.

I have added a new pre-run check to ensure the OS is x86_84 (64bit). As such, I have removed the logic to set arch based on OS arch and simply assume x64 as the test should prevent anything else.

Updated some comments to better reflect the code.